### PR TITLE
Update main_tpugraphs.py

### DIFF
--- a/main_tpugraphs.py
+++ b/main_tpugraphs.py
@@ -8,7 +8,7 @@ from graphgps.optimizer.extra_optimizers import ExtendedSchedulerConfig
 
 from torch_geometric.graphgym.cmd_args import parse_args
 from torch_geometric.graphgym.config import (cfg, dump_cfg,
-                                             set_agg_dir, set_cfg, load_cfg,
+                                             set_cfg, load_cfg,
                                              makedirs_rm_exist)
 from torch_geometric.graphgym.loader import create_loader
 from torch_geometric.graphgym.logger import set_printing


### PR DESCRIPTION
 "set_agg_dir" no longer exists in the latest version of torch_geometric.graphgym.config and not relevant in our case